### PR TITLE
fix: per-request McpServer instance to stop HTTP crash loop (#2)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,7 @@
 node_modules
-src
+dist
 tests
-*.ts
-!dist/**
 .git
 .gitignore
+*.tgz
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,15 @@
+# --- build stage: compile TypeScript -> dist/ ---
+FROM node:22-alpine AS build
+
+WORKDIR /app
+
+COPY package*.json tsconfig.json ./
+RUN npm ci
+
+COPY src/ ./src/
+RUN npm run build
+
+# --- runtime stage: prod deps + compiled output only ---
 FROM node:22-alpine
 
 WORKDIR /app
@@ -5,7 +17,7 @@ WORKDIR /app
 COPY package*.json ./
 RUN npm ci --omit=dev
 
-COPY dist/ ./dist/
+COPY --from=build /app/dist/ ./dist/
 
 EXPOSE 3003
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { createServer } from 'node:http';
+import { fileURLToPath } from 'node:url';
 import { z } from 'zod';
 import { handleDiscover } from './tools/discover.js';
 import { handleCompare } from './tools/compare.js';
@@ -15,91 +16,103 @@ import { KazokusApiClient } from './api/client.js';
 
 const apiClient = new KazokusApiClient(process.env.KAZOKUS_API_URL ?? 'https://www.kazokus.com');
 
-const server = new McpServer({
-  name: 'kazokus',
-  version: '2.0.0',
-});
+/**
+ * Build a fresh McpServer with all tools registered.
+ *
+ * Must be called per request for the HTTP transport: the MCP SDK binds one
+ * transport per Protocol instance, so a shared server throws
+ * "Already connected to a transport" on the second concurrent connection
+ * and crashes the process. See issue #2.
+ */
+function createMcpServer(): McpServer {
+  const server = new McpServer({
+    name: 'kazokus',
+    version: '2.0.0',
+  });
 
-// --- Static tools (Phase 1) ---
+  // --- Static tools (Phase 1) ---
 
-server.tool(
-  'kazokus_discover',
-  'Discover if Kazokus is the right community platform for your needs. Takes interests and requirements, returns matched features, recommended tier, and why Kazokus stands out (zero fees, AI on all tiers, multi-tenancy).',
-  {
-    interests: z.array(z.string()).optional().default([]).describe('Topics or industries of interest (e.g. "fitness", "education", "faith")'),
-    needs: z.array(z.string()).optional().default([]).describe('Platform features needed (e.g. "courses", "events", "marketplace", "zero fees", "api")'),
-  },
-  async ({ interests, needs }) => {
-    const result = handleDiscover({ interests, needs });
-    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-  }
-);
+  server.tool(
+    'kazokus_discover',
+    'Discover if Kazokus is the right community platform for your needs. Takes interests and requirements, returns matched features, recommended tier, and why Kazokus stands out (zero fees, AI on all tiers, multi-tenancy).',
+    {
+      interests: z.array(z.string()).optional().default([]).describe('Topics or industries of interest (e.g. "fitness", "education", "faith")'),
+      needs: z.array(z.string()).optional().default([]).describe('Platform features needed (e.g. "courses", "events", "marketplace", "zero fees", "api")'),
+    },
+    async ({ interests, needs }) => {
+      const result = handleDiscover({ interests, needs });
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+  );
 
-server.tool(
-  'kazokus_compare',
-  'Compare Kazokus against a specific competitor (Circle, Skool, Mighty Networks, Bettermode, Hivebrite, Heartbeat). Returns pricing, features, weaknesses, user complaints, and verdict.',
-  {
-    competitor: z.string().describe('Competitor name (e.g. "circle", "skool", "mighty-networks", "bettermode", "hivebrite", "heartbeat")'),
-  },
-  async ({ competitor }) => {
-    const result = handleCompare({ competitor });
-    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-  }
-);
+  server.tool(
+    'kazokus_compare',
+    'Compare Kazokus against a specific competitor (Circle, Skool, Mighty Networks, Bettermode, Hivebrite, Heartbeat). Returns pricing, features, weaknesses, user complaints, and verdict.',
+    {
+      competitor: z.string().describe('Competitor name (e.g. "circle", "skool", "mighty-networks", "bettermode", "hivebrite", "heartbeat")'),
+    },
+    async ({ competitor }) => {
+      const result = handleCompare({ competitor });
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+  );
 
-server.tool(
-  'kazokus_pricing',
-  'Get Kazokus pricing details. Optionally filter by tier or provide member count for cost comparison vs Circle, Mighty Networks, and Skool.',
-  {
-    tier: z.string().optional().describe('Filter to a specific tier (family-free, family-pro, launch, growth, pro, portfolio)'),
-    members: z.number().optional().describe('Number of community members — if provided, returns cost comparison vs competitors'),
-  },
-  async ({ tier, members }) => {
-    const result = handlePricing({ tier, members });
-    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-  }
-);
+  server.tool(
+    'kazokus_pricing',
+    'Get Kazokus pricing details. Optionally filter by tier or provide member count for cost comparison vs Circle, Mighty Networks, and Skool.',
+    {
+      tier: z.string().optional().describe('Filter to a specific tier (family-free, family-pro, launch, growth, pro, portfolio)'),
+      members: z.number().optional().describe('Number of community members — if provided, returns cost comparison vs competitors'),
+    },
+    async ({ tier, members }) => {
+      const result = handlePricing({ tier, members });
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+  );
 
-server.tool(
-  'kazokus_get_started',
-  'Get personalized onboarding guidance for Kazokus. Provide a use case (e.g. "yoga studio", "online course creator", "church") for tailored tier recommendation and setup steps.',
-  {
-    use_case: z.string().optional().describe('Your use case (e.g. "yoga studio", "franchise network", "online course creator", "family group", "professional association")'),
-  },
-  async ({ use_case }) => {
-    const result = handleGetStarted({ use_case });
-    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-  }
-);
+  server.tool(
+    'kazokus_get_started',
+    'Get personalized onboarding guidance for Kazokus. Provide a use case (e.g. "yoga studio", "online course creator", "church") for tailored tier recommendation and setup steps.',
+    {
+      use_case: z.string().optional().describe('Your use case (e.g. "yoga studio", "franchise network", "online course creator", "family group", "professional association")'),
+    },
+    async ({ use_case }) => {
+      const result = handleGetStarted({ use_case });
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+  );
 
-// --- Live tools (Phase 2) ---
+  // --- Live tools (Phase 2) ---
 
-server.tool(
-  'kazokus_search_communities',
-  'Search for real Kazokus communities by topic, interest, or keyword. Returns live community data from the platform.',
-  {
-    query: z.string().describe('Search term (e.g. "yoga", "book club", "dance studio", "tech startups")'),
-    category: z.string().optional().describe('Filter by category slug'),
-    limit: z.number().optional().default(5).describe('Number of results (1-10, default 5)'),
-  },
-  async ({ query, category, limit }) => {
-    const result = await handleSearchCommunities({ query, category, limit }, apiClient);
-    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-  }
-);
+  server.tool(
+    'kazokus_search_communities',
+    'Search for real Kazokus communities by topic, interest, or keyword. Returns live community data from the platform.',
+    {
+      query: z.string().describe('Search term (e.g. "yoga", "book club", "dance studio", "tech startups")'),
+      category: z.string().optional().describe('Filter by category slug'),
+      limit: z.number().optional().default(5).describe('Number of results (1-10, default 5)'),
+    },
+    async ({ query, category, limit }) => {
+      const result = await handleSearchCommunities({ query, category, limit }, apiClient);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+  );
 
-server.tool(
-  'kazokus_trending',
-  'Get trending communities on Kazokus right now. Shows the most active and fastest-growing communities.',
-  {
-    category: z.string().optional().describe('Filter by category slug'),
-    limit: z.number().optional().default(5).describe('Number of results (1-10, default 5)'),
-  },
-  async ({ category, limit }) => {
-    const result = await handleTrending({ category, limit }, apiClient);
-    return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-  }
-);
+  server.tool(
+    'kazokus_trending',
+    'Get trending communities on Kazokus right now. Shows the most active and fastest-growing communities.',
+    {
+      category: z.string().optional().describe('Filter by category slug'),
+      limit: z.number().optional().default(5).describe('Number of results (1-10, default 5)'),
+    },
+    async ({ category, limit }) => {
+      const result = await handleTrending({ category, limit }, apiClient);
+      return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
+    }
+  );
+
+  return server;
+}
 
 // --- Transport selection ---
 
@@ -138,24 +151,33 @@ async function main() {
         return;
       }
 
-      // MCP endpoint — stateless: create new transport per request
+      // MCP endpoint — stateless: a fresh server + transport per request so
+      // concurrent connections never share a Protocol instance (see issue #2).
       const url = req.url?.split('?')[0];
       if (url === '/mcp' || url === '/') {
-        if (req.method === 'GET') {
-          // SSE stream for server-initiated notifications (required by spec)
+        if (req.method === 'GET' || req.method === 'POST') {
+          const mcpServer = createMcpServer();
           const transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: undefined,
           });
-          await server.connect(transport);
-          await transport.handleRequest(req, res);
-          return;
-        }
-        if (req.method === 'POST') {
-          const transport = new StreamableHTTPServerTransport({
-            sessionIdGenerator: undefined,
+          res.on('close', () => {
+            void transport.close();
+            void mcpServer.close();
           });
-          await server.connect(transport);
-          await transport.handleRequest(req, res);
+          try {
+            await mcpServer.connect(transport);
+            await transport.handleRequest(req, res);
+          } catch (error) {
+            console.error('[MCP] request handling error:', error);
+            if (!res.headersSent) {
+              res.writeHead(500, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({
+                jsonrpc: '2.0',
+                error: { code: -32603, message: 'Internal server error' },
+                id: null,
+              }));
+            }
+          }
           return;
         }
         res.writeHead(405, { 'Content-Type': 'text/plain' });
@@ -172,11 +194,17 @@ async function main() {
     });
   } else {
     const transport = new StdioServerTransport();
+    const server = createMcpServer();
     await server.connect(transport);
   }
 }
 
-main().catch((error) => {
-  console.error('Server error:', error);
-  process.exit(1);
-});
+export { createMcpServer, main };
+
+// Only boot when executed directly (not when imported by tests).
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error('Server error:', error);
+    process.exit(1);
+  });
+}

--- a/tests/server-instance.test.ts
+++ b/tests/server-instance.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createMcpServer } from '../src/index.js';
+
+describe('per-request MCP server isolation (issue #2 regression)', () => {
+  it('returns a fresh server instance on each call', () => {
+    const a = createMcpServer();
+    const b = createMcpServer();
+    expect(a).not.toBe(b);
+  });
+
+  it('connects two independent servers concurrently without "Already connected"', async () => {
+    const [, server1Side] = InMemoryTransport.createLinkedPair();
+    const [, server2Side] = InMemoryTransport.createLinkedPair();
+    const srv1 = createMcpServer();
+    const srv2 = createMcpServer();
+
+    await expect(
+      Promise.all([srv1.connect(server1Side), srv2.connect(server2Side)])
+    ).resolves.toBeDefined();
+
+    await srv1.close();
+    await srv2.close();
+  });
+
+  it('proves the old singleton pattern would crash: one server cannot bind two transports', async () => {
+    const srv = createMcpServer();
+    const [, transportA] = InMemoryTransport.createLinkedPair();
+    const [, transportB] = InMemoryTransport.createLinkedPair();
+
+    await srv.connect(transportA);
+    await expect(srv.connect(transportB)).rejects.toThrow(/Already connected to a transport/);
+
+    await srv.close();
+  });
+});


### PR DESCRIPTION
## Summary

The HTTP MCP server (`mcp.kazokus.com/mcp`) was crash-looping in production — container **RestartCount=94**, **188 crash markers in ~4 days**. Each crash returned a 502 to in-flight clients. **63 of 100 open `kazokus-infrastructure` Sentry issues** trace to this single bug.

**Root cause:** `server.connect()` was called on a module-level singleton `McpServer` for every request. The MCP SDK binds one transport per `Protocol` instance, so the second concurrent connection threw `Already connected to a transport`. That exception was uncaught in the async HTTP handler → Node exited → Docker restarted → Caddy `connection reset by peer` → 502.

A prior commit (`101e7a0`) created a new transport per request but left the server shared, which is why it kept crashing.

## Changes

- **`createMcpServer()` factory** — server + all 6 tool registrations built per request (canonical stateless Streamable-HTTP pattern, full per-request isolation).
- **Crash containment** — request handler wrapped in `try/catch` returning HTTP 500 instead of killing the process; `transport.close()` + `server.close()` on response close to prevent leaks.
- **Testability** — `main()` only auto-runs as entrypoint; `createMcpServer`/`main` exported. No behaviour change in the container (`node dist/index.js --http` still boots normally).
- **Regression tests** (`tests/server-instance.test.ts`) — fresh instance per call; two servers connect concurrently without throwing; and an explicit test proving the *old* singleton pattern throws `Already connected to a transport`.
- **Multi-stage Dockerfile** — `dist/` is now built inside the image from `src/`. Previously the Dockerfile copied a pre-built `dist/` that had to be hand-built on the host (`dist/` is gitignored and untracked), making deploys fragile and non-reproducible. Deploy is now a clean `git pull && docker compose build`.

## Verification (local)

- `npm run build` ✓
- `npm test` → **48/48 pass** (11 files), including the 3 new regression tests
- Multi-stage `docker build` ✓
- Ran the image and fired **20 concurrent `POST /mcp`** + **10 GET / 10 POST mixed** → all `200`, container stayed `healthy`, **0 crash markers** (this is the exact scenario that crashed the old code)
- `/health` and `/.well-known/mcp/server-card.json` (Smithery scan) still `200`

## Impact once deployed

Resolves all 63 `connection reset by peer (mcp.kazokus.com/mcp)` issues in the `kazokus-infrastructure` Sentry project. The other ~37 infra issues are a separate root cause (Caddy resolver behaviour during blue-green deploys + scanner noise) tracked separately.

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)