### PR TITLE
fix: stateless server returns 405 for GET /mcp per spec

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,27 +116,25 @@ function createMcpServer(): McpServer {
 
 // --- Transport selection ---
 
-async function main() {
-  const useHttp = process.argv.includes('--http') || !!process.env.PORT;
+const SERVER_CARD = JSON.stringify({
+  serverInfo: { name: 'kazokus', version: '2.0.0' },
+  tools: [
+    { name: 'kazokus_discover', description: 'Find out if Kazokus is the right community platform for your needs', inputSchema: { type: 'object', properties: { interests: { type: 'array', items: { type: 'string' } }, needs: { type: 'array', items: { type: 'string' } } } } },
+    { name: 'kazokus_compare', description: 'Compare Kazokus vs Circle, Skool, Mighty Networks, Bettermode, Hivebrite, or Heartbeat', inputSchema: { type: 'object', properties: { competitor: { type: 'string' } }, required: ['competitor'] } },
+    { name: 'kazokus_pricing', description: 'Get Kazokus pricing with optional cost comparison vs competitors', inputSchema: { type: 'object', properties: { tier: { type: 'string' }, members: { type: 'number' } } } },
+    { name: 'kazokus_get_started', description: 'Get personalized onboarding guidance and tier recommendation', inputSchema: { type: 'object', properties: { use_case: { type: 'string' } } } },
+    { name: 'kazokus_search_communities', description: 'Search for real Kazokus communities by topic, interest, or keyword', inputSchema: { type: 'object', properties: { query: { type: 'string' }, category: { type: 'string' }, limit: { type: 'number' } }, required: ['query'] } },
+    { name: 'kazokus_trending', description: 'Get trending communities on Kazokus right now', inputSchema: { type: 'object', properties: { category: { type: 'string' }, limit: { type: 'number' } } } },
+  ],
+  resources: [],
+  prompts: [],
+});
 
-  if (useHttp) {
-    const port = parseInt(process.env.PORT ?? '3003', 10);
+/** Build the HTTP server (not yet listening) so it can be unit-tested. */
+function buildHttpServer() {
+  const serverCard = SERVER_CARD;
 
-    const serverCard = JSON.stringify({
-      serverInfo: { name: 'kazokus', version: '2.0.0' },
-      tools: [
-        { name: 'kazokus_discover', description: 'Find out if Kazokus is the right community platform for your needs', inputSchema: { type: 'object', properties: { interests: { type: 'array', items: { type: 'string' } }, needs: { type: 'array', items: { type: 'string' } } } } },
-        { name: 'kazokus_compare', description: 'Compare Kazokus vs Circle, Skool, Mighty Networks, Bettermode, Hivebrite, or Heartbeat', inputSchema: { type: 'object', properties: { competitor: { type: 'string' } }, required: ['competitor'] } },
-        { name: 'kazokus_pricing', description: 'Get Kazokus pricing with optional cost comparison vs competitors', inputSchema: { type: 'object', properties: { tier: { type: 'string' }, members: { type: 'number' } } } },
-        { name: 'kazokus_get_started', description: 'Get personalized onboarding guidance and tier recommendation', inputSchema: { type: 'object', properties: { use_case: { type: 'string' } } } },
-        { name: 'kazokus_search_communities', description: 'Search for real Kazokus communities by topic, interest, or keyword', inputSchema: { type: 'object', properties: { query: { type: 'string' }, category: { type: 'string' }, limit: { type: 'number' } }, required: ['query'] } },
-        { name: 'kazokus_trending', description: 'Get trending communities on Kazokus right now', inputSchema: { type: 'object', properties: { category: { type: 'string' }, limit: { type: 'number' } } } },
-      ],
-      resources: [],
-      prompts: [],
-    });
-
-    const httpServer = createServer(async (req, res) => {
+  return createServer(async (req, res) => {
       // Health check
       if (req.url === '/health' && req.method === 'GET') {
         res.writeHead(200, { 'Content-Type': 'text/plain' });
@@ -155,7 +153,7 @@ async function main() {
       // concurrent connections never share a Protocol instance (see issue #2).
       const url = req.url?.split('?')[0];
       if (url === '/mcp' || url === '/') {
-        if (req.method === 'GET' || req.method === 'POST') {
+        if (req.method === 'POST') {
           const mcpServer = createMcpServer();
           const transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: undefined,
@@ -180,16 +178,32 @@ async function main() {
           }
           return;
         }
-        res.writeHead(405, { 'Content-Type': 'text/plain' });
-        res.end('Method not allowed');
+        // Stateless server (sessionIdGenerator: undefined) has no session to
+        // attach a server->client stream to, so GET/DELETE are not supported.
+        // Per the MCP Streamable-HTTP spec, return 405 with a JSON-RPC error.
+        res.writeHead(405, {
+          'Content-Type': 'application/json',
+          'Allow': 'POST',
+        });
+        res.end(JSON.stringify({
+          jsonrpc: '2.0',
+          error: { code: -32000, message: 'Method not allowed. This server is stateless; use POST.' },
+          id: null,
+        }));
         return;
       }
 
       res.writeHead(404);
       res.end('Not found');
     });
+}
 
-    httpServer.listen(port, () => {
+async function main() {
+  const useHttp = process.argv.includes('--http') || !!process.env.PORT;
+
+  if (useHttp) {
+    const port = parseInt(process.env.PORT ?? '3003', 10);
+    buildHttpServer().listen(port, () => {
       console.log(`Kazokus MCP server (HTTP) listening on port ${port}`);
     });
   } else {
@@ -199,7 +213,7 @@ async function main() {
   }
 }
 
-export { createMcpServer, main };
+export { createMcpServer, buildHttpServer, main };
 
 // Only boot when executed directly (not when imported by tests).
 if (process.argv[1] === fileURLToPath(import.meta.url)) {

--- a/tests/http-server.test.ts
+++ b/tests/http-server.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Server } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { buildHttpServer } from '../src/index.js';
+
+let server: Server;
+let base: string;
+
+beforeAll(async () => {
+  server = buildHttpServer();
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const { port } = server.address() as AddressInfo;
+  base = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve()))
+  );
+});
+
+const POST_BODY = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'tools/list',
+  params: {},
+});
+
+describe('HTTP server contract', () => {
+  it('GET /health returns 200 ok', async () => {
+    const res = await fetch(`${base}/health`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ok');
+  });
+
+  it('GET /.well-known/mcp/server-card.json returns 200 JSON (Smithery scan)', async () => {
+    const res = await fetch(`${base}/.well-known/mcp/server-card.json`);
+    expect(res.status).toBe(200);
+    const card = await res.json();
+    expect(card.serverInfo.name).toBe('kazokus');
+    expect(card.tools.length).toBe(6);
+  });
+
+  it('GET /mcp returns 405 with a JSON-RPC error (stateless: POST only)', async () => {
+    const res = await fetch(`${base}/mcp`, { headers: { Accept: 'text/event-stream' } });
+    expect(res.status).toBe(405);
+    expect(res.headers.get('allow')).toBe('POST');
+    const body = await res.json();
+    expect(body.jsonrpc).toBe('2.0');
+    expect(body.error.code).toBe(-32000);
+    expect(body.error.message).toMatch(/stateless/i);
+  });
+
+  it('GET / also returns 405 (same MCP endpoint alias)', async () => {
+    const res = await fetch(`${base}/`, { headers: { Accept: 'text/event-stream' } });
+    expect(res.status).toBe(405);
+  });
+
+  it('POST /mcp tools/list returns 200 with the tool list', async () => {
+    const res = await fetch(`${base}/mcp`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+      body: POST_BODY,
+    });
+    expect(res.status).toBe(200);
+    const text = await res.text();
+    expect(text).toContain('kazokus_discover');
+  });
+
+  it('20 concurrent POSTs do not crash the server (issue #2 regression)', async () => {
+    const results = await Promise.all(
+      Array.from({ length: 20 }, () =>
+        fetch(`${base}/mcp`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+          body: POST_BODY,
+        }).then((r) => r.status)
+      )
+    );
+    expect(results.every((s) => s === 200)).toBe(true);
+
+    // Server still responsive afterwards.
+    const health = await fetch(`${base}/health`);
+    expect(health.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #3. The stateless MCP server (`sessionIdGenerator: undefined`) has no session to attach a server→client SSE stream to, so `GET /mcp` opened a stream that never emitted and hung until the client timed out. Per the MCP Streamable-HTTP spec and the SDK's own stateless example, `GET`/`DELETE` should return **405** with a JSON-RPC error + `Allow: POST`.

This was flagged during the #3 deploy verification (GET hung with `curl` returning `http=000`).

## Changes

- `GET /mcp` and `GET /` → **405** JSON-RPC error (`code: -32000`, message references stateless/use POST), `Allow: POST` header.
- `POST /mcp` unchanged — per-request server+transport, 200.
- Smithery scanning unaffected: static `/.well-known/mcp/server-card.json` (200) + POST (200).
- Extracted `buildHttpServer()` (returns a non-listening `http.Server`) so the HTTP contract is unit-testable; `main()` just `.listen()`s it.
- New `tests/http-server.test.ts`: real HTTP integration tests — 405 contract, POST 200 with tool list, /health, server-card, and a 20-concurrent-POST no-crash regression (issue #2) at the HTTP layer.

## Verification (local)

- `npm run build` ✓
- `npm test` → **54/54 pass** (12 files)
- Docker image smoke: `GET /mcp` → 405 (fast, correct JSON-RPC body, no hang); `POST /mcp tools/list` → 200 with full tool list; `POST initialize` → 200; server-card → 200; clean logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)